### PR TITLE
Trusty produces an exception when using an RSA key

### DIFF
--- a/src/main/java/ru/ussgroup/security/trusty/TrustyUtils.java
+++ b/src/main/java/ru/ussgroup/security/trusty/TrustyUtils.java
@@ -91,7 +91,12 @@ public class TrustyUtils {
     
     public static byte[] sign(byte[] data, PrivateKey privateKey) throws SignatureException {
         try {
-            Signature signature = Signature.getInstance(privateKey.getAlgorithm());
+            Signature signature;
+            if (privateKey.getAlgorithm().equals("RSA")) {
+                signature = Signature.getInstance("SHA256withRSA");
+            } else {
+                signature = Signature.getInstance(privateKey.getAlgorithm());
+            }
             
             signature.initSign(privateKey);
             signature.update(data);


### PR DESCRIPTION
Trusty produces an exception when using an RSA key with ESF SDK. Should use a hashing algorithm instead.

Caused by: java.security.SignatureException: java.lang.IllegalArgumentException: input data too large
	at org.bouncycastle.jcajce.provider.asymmetric.rsa.DigestSignatureSpi.engineSign(Unknown Source) ~[bcprov-jdk15on-1.57.jar:1.57.0]
	at java.security.Signature$Delegate.engineSign(Signature.java:1207) ~[?:1.8.0_131]
	at java.security.Signature.sign(Signature.java:579) ~[?:1.8.0_131]
	at ru.ussgroup.security.trusty.TrustyUtils.sign(TrustyUtils.java:99) ~[trusty-0.5.jar:?]
	at ru.ussgroup.security.trusty.TrustyUtils.sign(TrustyUtils.java:89) ~[trusty-0.5.jar:?]
	at ru.uss.common.util.SignatureHelper.sign(SignatureHelper.java:88) ~[esf-security-13.10.2017.jar:?]
	at ru.uss.esf.util.InvoiceSignatureHelper.sign(InvoiceSignatureHelper.java:16) ~[esf-model-13.10.2017.jar:?]
	at ru.uss.esf.client.impl.SessionClientAPI1.create(SessionClientAPI1